### PR TITLE
Remove spaces from table & column names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="target-postgres",
-    version="1.1.8",
+    version="1.1.9",
     description="Singer.io target for Postgres",
     author="Statsbot",
     url="https://statsbot.co",

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -338,6 +338,7 @@ class DbSync:
     def sync_table(self):
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message['stream']
+        stream = inflect_name(stream)
         found_tables = [table for table in (self.get_tables()) if table['table_name'].lower() == stream.lower()]
         if len(found_tables) == 0:
             query = self.create_table_query()

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -29,7 +29,8 @@ def column_type(schema_property):
         return 'character varying'
 
 
-def inflect_column_name(name):
+def inflect_name(name):
+    name = name.replace(' ', '_')
     name = re.sub(r"([A-Z]+)_([A-Z][a-z])", r'\1__\2', name)
     name = re.sub(r"([a-z\d])_([A-Z])", r'\1__\2', name)
     return inflection.underscore(name)
@@ -45,7 +46,7 @@ def column_clause(name, schema_property):
 
 def flatten_key(k, parent_key, sep):
     full_key = parent_key + [k]
-    inflected_key = [inflect_column_name(n) for n in full_key]
+    inflected_key = [inflect_name(n) for n in full_key]
     reducer_index = 0
     while len(sep.join(inflected_key)) >= 63 and reducer_index < len(inflected_key):
         reduced_key = re.sub(r'[a-z]', '', inflection.camelize(inflected_key[reducer_index]))
@@ -96,7 +97,7 @@ def flatten_record(d, parent_key=[], sep='__'):
 
 
 def primary_column_names(stream_schema_message):
-    return [safe_column_name(inflect_column_name(p)) for p in stream_schema_message['key_properties']]
+    return [safe_column_name(inflect_name(p)) for p in stream_schema_message['key_properties']]
 
 
 class DbSync:
@@ -136,6 +137,8 @@ class DbSync:
                 cur.copy_from(file, table)
 
     def table_name(self, table_name, is_temporary):
+        table_name = inflect_name(table_name)
+
         if is_temporary:
             return '{}_temp'.format(table_name)
         else:
@@ -145,7 +148,7 @@ class DbSync:
         if len(self.stream_schema_message['key_properties']) == 0:
             return None
         flatten = flatten_record(record)
-        key_props = [str(flatten[inflect_column_name(p)]) for p in self.stream_schema_message['key_properties']]
+        key_props = [str(flatten[inflect_name(p)]) for p in self.stream_schema_message['key_properties']]
         return ','.join(key_props)
 
     def record_to_csv_row(self, record):
@@ -293,7 +296,7 @@ class DbSync:
     def update_columns(self):
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message['stream']
-        columns = self.get_table_columns(stream)
+        columns = self.get_table_columns(inflect_name(stream))
         columns_dict = {column['column_name'].lower(): column for column in columns}
 
         columns_to_add = [

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -30,8 +30,11 @@ def column_type(schema_property):
 
 
 def inflect_name(name):
-    name = re.sub(r'[^a-zA-Z0-9 ]', '', name)
-    name = name.replace(' ', '_')
+
+    # By modifying the name here , we introduce the possibility of having
+    # duplicate column or table names. This will be much more likely to happen
+    # with arbitrary user input
+    name = re.sub(r'[^a-zA-Z0-9]', '_', name)
     name = re.sub(r"([A-Z]+)_([A-Z][a-z])", r'\1__\2', name)
     name = re.sub(r"([a-z\d])_([A-Z])", r'\1__\2', name)
     return inflection.underscore(name)

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -30,6 +30,7 @@ def column_type(schema_property):
 
 
 def inflect_name(name):
+    name = re.sub(r'[^a-zA-Z0-9 ]', '', name)
     name = name.replace(' ', '_')
     name = re.sub(r"([A-Z]+)_([A-Z][a-z])", r'\1__\2', name)
     name = re.sub(r"([a-z\d])_([A-Z])", r'\1__\2', name)


### PR DESCRIPTION
This helps with the new google-sheets tap, which might have sheet names and/or column names with spaces in their names, which doesn't work so well with postgres! 