### PR TITLE
Always create PostgreSQL tables using TIMESTAMP WITH TIME ZONE.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="target-postgres",
-    version="1.1.11",
+    version="1.1.12",
     description="Singer.io target for Postgres",
     author="Statsbot",
     url="https://statsbot.co",


### PR DESCRIPTION
The Singer spec best practices asks for timestamps with timezone, so there is no reason that we should not include the information if given.

This change should be backwards compatible. It will not drop the column if it doesn't already include a time zone. That will need to be a manual migration.

Tested locally, using our Zendesk tap fork.

Bump version to 1.1.12.