### PR TITLE
Include non-null values

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -90,13 +90,13 @@ def persist_lines(config, lines):
             primary_key_string = sync.record_primary_key_string(o['record'])
             if stream not in primary_key_exists:
                 primary_key_exists[stream] = {}
-            if primary_key_string and primary_key_string in primary_key_exists[stream]:
+            if primary_key_string is not None and primary_key_string in primary_key_exists[stream]:
                 flush_records(o, csv_files_to_load, row_count, primary_key_exists, sync)
 
             writer = csv_files_to_load[o['stream']]['writer']
             writer.writerow(sync.record_to_csv_row(o['record']))
             row_count[o['stream']] += 1
-            if primary_key_string:
+            if primary_key_string is not None:
                 primary_key_exists[stream][primary_key_string] = True
 
             if row_count[o['stream']] >= batch_size:

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -169,7 +169,7 @@ class DbSync:
         row = []
         flatten = flatten_record(record)
         for name, schema in self.flatten_schema.items():
-            if flatten.get(name):
+            if flatten.get(name) is not None:
                 type = column_type(schema).lower()
                 value = flatten[name]
                 if type == 'jsonb':


### PR DESCRIPTION
This will probably update a lot of existing rows because checking truthy means it'll skip values where it shouldn't like False, 0, '', etc. Instead, explicitly check if the value `is not None`.  For example, a primary key ID can be 0 and would fail the not-null constraint on upsert.
https://docs.python.org/3/library/stdtypes.html#truth-value-testing