### PR TITLE
Handle falsy values for the 'record' property

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -85,6 +85,11 @@ def persist_lines(config, lines):
             # Validate record
             validators[stream].validate(o['record'])
 
+            # Ensure the record is not None
+            if not o['record']:
+                logger.warning(f'A record for stream {o["stream"]} is invalid which can violate constraints. Skipping line: {o}')
+                continue
+
             sync = stream_to_sync[stream]
 
             primary_key_string = sync.record_primary_key_string(o['record'])

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -102,6 +102,8 @@ def flatten_schema(d, parent_key=[], sep='__'):
 
 
 def flatten_record(d, parent_key=[], sep='__'):
+    if not d or not isinstance(d, dict):
+        return {}
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
@@ -162,6 +164,8 @@ class DbSync:
 
     def record_primary_key_string(self, record):
         if len(self.stream_schema_message['key_properties']) == 0:
+            return None
+        if not record:
             return None
         flatten = flatten_record(record)
         key_props = [str(flatten[inflect_name(p)]) for p in self.stream_schema_message['key_properties']]

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -215,5 +215,16 @@ def test_dbsync_table_name(table_name: str, is_temporary: bool, expected: str, d
 def test_record_to_csv_row(record: dict, expected: list, dbsync_class: DbSync):
     assert sorted(dbsync_class.record_to_csv_row(record)) == sorted(expected)
 
-
-def test_record_primary_key_string(record:)
+@pytest.mark.parametrize(
+    'record,key_props,expected',
+    [   
+        ({'id': '1', 'custom_fields': {'app': {'value': 'nested'}}}, [], None),
+        ({}, ['id'], None),
+        ({'id': '1', 'custom_fields': {'app': {'value': 'nested'}}}, ['id'], '1'),
+        ({'test__primary': 1}, ['Test Primary'], '1'),
+        ({'test__primary': 1, 'test_secondary': 2}, ['Test Primary', 'Test_secondary'], '1,2'),
+    ]
+)
+def test_record_primary_key_string(record, key_props: list, expected: str, dbsync_class: DbSync):
+    dbsync_class.stream_schema_message['key_properties'] = key_props
+    assert dbsync_class.record_primary_key_string(record) == expected

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -144,10 +144,50 @@ def test_flatten_schema(additional_prop_kwargs: dict, expected: dict):
     sorted_expected = sorted(expected.items(), key=_sort)
     assert sorted_flattened == sorted_expected
 
-def test_flatten_record():
-    record = {'id': '1', 'custom_fields': {'app': {'value': 'nested'}}}
-    expected = {'id': '1', 'custom_fields__app__value': 'nested'}
-    assert flatten_record(record) == expected
+@pytest.mark.parametrize(
+    'record,expected',
+    [
+        (
+            # Test a nested field and perserves other key values
+            {'id': '1', 'custom_fields': {'app': {'value': 'nested'}}},
+            {'id': '1', 'custom_fields__app__value': 'nested'}
+        ),
+        (
+            # Test a nested field with multiple key values
+            {'custom_fields': {'app': {'value': 'nested', 'value2': 'nested2'}}},
+            {'custom_fields__app__value': 'nested', 'custom_fields__app__value2': 'nested2'}
+        ),
+        (
+            # Test a nested field with array value of same types, calls json.dumps
+            {'custom_fields': {'app': {'value': ['1', '2']}}},
+            {'custom_fields__app__value': '["1", "2"]'}
+        ),
+        (
+            # Test a nested field with array value of varying types, calls json.dumps
+            {'custom_fields': {'app': {'value': [1, '2', {'a': 3}]}}},
+            {'custom_fields__app__value': '[1, "2", {"a": 3}]'}
+        ),
+        (
+            # Test a nested field with tuple value of same types
+            {'custom_fields': {'app': {'value': (1, 2)}}},
+            {'custom_fields__app__value': (1, 2)}
+        ),
+        (
+            # Test a nested field with tuple value of varying types
+            {'custom_fields': {'app': {'value': (1, '2', {'a': 3})}}},
+            {'custom_fields__app__value': (1, '2', {'a': 3})}
+        ),
+        ({'id': 1}, {'id': 1}),
+        (None, {}),
+        ([], {}),
+        ({}, {}),
+        ('some_value', {}),
+    ]
+)
+def test_flatten_record(record, expected: dict):
+    actual = flatten_record(record)
+    assert actual == expected
+    assert isinstance(actual, dict)
 
 @pytest.mark.parametrize(
     'table_name,is_temporary,expected',
@@ -174,3 +214,6 @@ def test_dbsync_table_name(table_name: str, is_temporary: bool, expected: str, d
 )
 def test_record_to_csv_row(record: dict, expected: list, dbsync_class: DbSync):
     assert sorted(dbsync_class.record_to_csv_row(record)) == sorted(expected)
+
+
+def test_record_primary_key_string(record:)


### PR DESCRIPTION
JIRA Key: https://pathlighthq.atlassian.net/browse/FUJ-2070

Splunk logs:
https://splunk.pathlight.com/en-GB/app/search/search?q=search%20%22AttributeError%3A%20%27NoneType%27%20object%20has%20no%20attribute%20%27items%27%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now&sid=1653508012.6219924

Includes tests for changes

Edit:
Think it's mainly related to Zendesk taps, not really sure about other datasources. Perhaps there was a change in Zendesks API or how the record data is processed?