### PR TITLE
Allow nested dictionaries to be selected as DB columns

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -108,17 +108,17 @@ def flatten_record(d, parent_key=[], sep='__'):
 
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.abc.MutableMapping):
+        mutable_class = collections.abc.MutableMapping if hasattr(collections, 'abc') else collections.MutableMapping
+        if isinstance(v, mutable_class):
             items.extend(flatten_record(v, parent_key + [k], sep=sep).items())
-            if len(parent_key) > 0:
-                #  Note: without the following line, all the keys will be flattened
-                #  including nested dictionaries.
-                #  For example:
-                #      {'answers': {'q1': 'some_string', 'some_dict': {'q2': 'some_string2'}}}
-                #  will be transformed to
-                #      [('answers__q1', 'some_string'), ('answers__some_dict__q2', 'some_string2')]
-                #  so we need to add an additional item to be able to select the 'answers__some_dict' key.
-                items.append((new_key, json.dumps(v)))
+            #  Note: without the following line, all the keys will be flattened
+            #  including nested dictionaries.
+            #  For example:
+            #      {'answers': {'q1': 'some_string', 'some_dict': {'q2': 'some_string2'}}}
+            #  will be transformed to
+            #      [('answers__q1', 'some_string'), ('answers__some_dict__q2', 'some_string2')]
+            #  so we need to add an additional item to be able to select the 'answers__some_dict' key.
+            items.append((new_key, json.dumps(v)))
         else:
             items.append((new_key, json.dumps(v) if type(v) is list else v))
     return dict(items)

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -105,10 +105,20 @@ def flatten_record(d, parent_key=[], sep='__'):
     if not d or not isinstance(d, dict):
         return {}
     items = []
+
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, collections.abc.MutableMapping):
             items.extend(flatten_record(v, parent_key + [k], sep=sep).items())
+            if len(parent_key) > 0:
+                #  Note: without the following line, all the keys will be flattened
+                #  including nested dictionaries.
+                #  For example:
+                #      {'answers': {'q1': 'some_string', 'some_dict': {'q2': 'some_string2'}}}
+                #  will be transformed to
+                #      [('answers__q1', 'some_string'), ('answers__some_dict__q2', 'some_string2')]
+                #  so we need to add an additional item to be able to select the 'answers__some_dict' key.
+                items.append((new_key, json.dumps(v)))
         else:
             items.append((new_key, json.dumps(v) if type(v) is list else v))
     return dict(items)

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -148,34 +148,38 @@ def test_flatten_schema(additional_prop_kwargs: dict, expected: dict):
     'record,expected',
     [
         (
+            {'id': '1', 'custom_fields': {'app': 'value'}},
+            {'id': '1', 'custom_fields__app': 'value'}
+        ),
+        (
             # Test a nested field and perserves other key values
             {'id': '1', 'custom_fields': {'app': {'value': 'nested'}}},
-            {'id': '1', 'custom_fields__app__value': 'nested'}
+            {'id': '1', 'custom_fields__app': '{"value": "nested"}', 'custom_fields__app__value': 'nested'}
         ),
         (
             # Test a nested field with multiple key values
             {'custom_fields': {'app': {'value': 'nested', 'value2': 'nested2'}}},
-            {'custom_fields__app__value': 'nested', 'custom_fields__app__value2': 'nested2'}
+            {'custom_fields__app': '{"value": "nested", "value2": "nested2"}', 'custom_fields__app__value': 'nested', 'custom_fields__app__value2': 'nested2'}
         ),
         (
             # Test a nested field with array value of same types, calls json.dumps
             {'custom_fields': {'app': {'value': ['1', '2']}}},
-            {'custom_fields__app__value': '["1", "2"]'}
+            {'custom_fields__app': '{"value": ["1", "2"]}', 'custom_fields__app__value': '["1", "2"]'}
         ),
         (
             # Test a nested field with array value of varying types, calls json.dumps
             {'custom_fields': {'app': {'value': [1, '2', {'a': 3}]}}},
-            {'custom_fields__app__value': '[1, "2", {"a": 3}]'}
+            {'custom_fields__app': '{"value": [1, "2", {"a": 3}]}', 'custom_fields__app__value': '[1, "2", {"a": 3}]'}
         ),
         (
             # Test a nested field with tuple value of same types
             {'custom_fields': {'app': {'value': (1, 2)}}},
-            {'custom_fields__app__value': (1, 2)}
+            {'custom_fields__app': '{"value": [1, 2]}', 'custom_fields__app__value': (1, 2)}
         ),
         (
             # Test a nested field with tuple value of varying types
             {'custom_fields': {'app': {'value': (1, '2', {'a': 3})}}},
-            {'custom_fields__app__value': (1, '2', {'a': 3})}
+            {'custom_fields__app': '{"value": [1, "2", {"a": 3}]}', 'custom_fields__app__value': (1, '2', {'a': 3})}
         ),
         ({'id': 1}, {'id': 1}),
         (None, {}),
@@ -188,6 +192,7 @@ def test_flatten_record(record, expected: dict):
     actual = flatten_record(record)
     assert actual == expected
     assert isinstance(actual, dict)
+
 
 @pytest.mark.parametrize(
     'table_name,is_temporary,expected',

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -193,7 +193,6 @@ def test_flatten_record(record, expected: dict):
     assert actual == expected
     assert isinstance(actual, dict)
 
-
 @pytest.mark.parametrize(
     'table_name,is_temporary,expected',
     [


### PR DESCRIPTION
JIRA Key: FUJ-2833

So this is a really interesting problem. By design we flatten all nested dictionaries, regardless of whether they are a child of a top-level record field.

For the Ancestry implementation, we have records that contain nested dictionaries with arbitrary key/values inside of them, ex:
```
'answers': {
    'agent_star_rating': {
        'question_id': 328,
        'question_text': "{% case channel %}\n{% when 'phone' %}...", 
        'comment': None, 
        'selected_options': {
            '2643': {
                 'option_id': 2643,
                 'option_text': '5',
                 'integer_value': 5
            }
         }
}
...
``` 
Due to the shape of the data, we cannot selected the specific underlying keys (ex. `selected_options__2642`) because they vary from record to record.

Our catalog looks like this (https://admin.pathlight.com/admin/dw/tapconfig/20c423a7-df9c-4b51-ba26-624210851914/change/?_changelist_filters=type%3Dstella):
```
"answers": {
    "type": [
        "null", 
        "object"
    ],
    "properties": {
        "agent_star_rating": {
            "type": [
                  "null",
                  "object"
             ]
        }
     }
}
```

Currently the expected behavior from the target is to disregard these nested dict keys and flatten them all the way down. So in the example above, here are the items that are returned from the `flatten_records` method:
```
 [('answers__agent_star_rating__question_id', 328), 
  ('answers__agent_star_rating__question_text', "{% case channel %}\n..."), 
  ('answers__agent_star_rating__comment', None),
  ('answers__agent_star_rating__selected_options___2643__option_id', 2643), 
  ('ans__agent_star_rating__selected_options___2643__option_text', '5'),
  ('ans__agent_star_rating__selected_options___2643__integer_value', 5), 
   ...
]
```
Note that there is no `answers__agent_star_rating` for us to write to the DB! That's why the columns were always empty when the tap would sync.

The fix here is to also include a JSON string of the nested dictionary, in addition to all of the flattened keys. After my change, here are the new items returned from the `flatten_records` method:
```
 [('answers__agent_star_rating__question_id', 328), 
  ('answers__agent_star_rating__question_text', "{% case change..."), 
  ('answers__agent_star_rating__comment', None), 
  ('answers__agent_star_rating__selected_options___2643__option_id', 2643), 
  ('ans__agent_star_rating__selected_options___2643__option_text', '5'), 
  ('ans__agent_star_rating__selected_options___2643__integer_value', 5), 
  ('answers__agent_star_rating__selected_options___2643', '{"option_id": 2643, "option_text": "5", "integer_value": 5}'), 
  ('answers__agent_star_rating__selected_options', '{"2643": {"option_id": 2643, "option_text": "5", "integer_value": 5}}'), 
  ('answers__agent_star_rating', '{"question_id": 328, "question_...'),
  ...
```
So now both `answers__agent_star_rating` and `answers__agent_star_rating__selected_options` are columns that we can write to the DB. 

This won't cause any extra data to be saved by default because I skip the top-level keys (when `len(parent_key) == 0`) and the nested dictionaries are not automatically added to the catalog.

Here is a verification that the data is written to the local DB:
```
dw=# select answers__agent_star_rating from tap_stella.feedback where sequence_id = '16637957429248';

{"comment": null, "question_id": 328, "question_text": "{% case channel %}\n{% when 'phone' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'chat' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'email' %}How satisfied are you with the service you received from {{employee.first_name}}?\n{% when 'social' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'community' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'email-to-case' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'outbound-email' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'directly' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'chatbot' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'sms' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'rtm' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% when 'whatsapp' %}How satisfied are you with the service you received from {{employee.first_name}} today?\n{% endcase %}", "selected_options": {"2639": {"option_id": 2639, "option_text": "1", "integer_value": 1}}}
```