### PR TITLE
Rewrite column_type() to choose the most general type to use in postgres

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -10,25 +10,99 @@ import itertools
 logger = singer.get_logger()
 
 
+JSONSCHEMA_TYPES = (
+    'string',
+    'number',
+    'integer',
+    'object',
+    'array',
+    'boolean',
+    'null',
+)
+
+
+JSONSCHEMA_TYPE_TO_POSTGRES_TYPE = {
+    'string': 'character varying',
+    'number': 'numeric',
+    'integer': 'bigint',
+    'object': 'jsonb',
+    'array': 'jsonb',
+    'boolean': 'boolean',
+}
+
+
+_JSONSCHEMA_TYPE_CAN_CAST_TO = {
+    'string': JSONSCHEMA_TYPES,
+    'number': ('integer', 'boolean'),
+    'integer': ('boolean',),
+    'object': ('array',),
+    'array': (),
+    'boolean': (),
+    # We never want to cast a non-null to null
+    'null': ()
+}
+
+
+def get_castable_types(target_type):
+    """
+    Returns the set of types that can be safely converted to target_type
+    """
+    accepts = set(_JSONSCHEMA_TYPE_CAN_CAST_TO.get(target_type, ()))
+    accepts |= {target_type,}
+    return accepts
+
+
+def most_general_type(types):
+    """
+    Figures out the most general type in the list, which allows us to make a
+    more intelligent choice about which postgres data type to use.
+
+    A type G is more general than a type T iff `cast(g AS t)` losslessly
+    converts g to t without error where `g` is of type `G` and `t` is of type
+    `T`.
+    """
+    if not types:
+        raise ValueError('most_general_type: types requires at least 1 entry')
+    types = set(types)
+
+    best_score, best_type = 0, None
+
+    # Iterate over sorted types so that the same type always wins if two types
+    # have equal scores.
+    for t in sorted(types):
+        castable_types = get_castable_types(t)
+        # The score is the number of types in `types` that can be cast to the
+        # type `t`. The most general one is the one that accepts the most casts
+        # to it.
+        score = len(castable_types.intersection(types))
+        if score > best_score:
+            best_score, best_type = score, t
+
+    if not get_castable_types(best_type).issuperset(types):
+        # The best type we found can't accomodate all `types`, so return
+        # `string`, which is the most general type of all.
+        best_type = 'string'
+
+    return best_type
+
+
 def column_type(schema_property):
-    property_type = schema_property['type']
     property_format = schema_property['format'] if 'format' in schema_property else None
-    if 'object' in property_type or 'array' in property_type:
-        return 'jsonb'
-    elif property_format == 'date-time':
-        return 'timestamp with time zone'
-    elif property_format == 'date':
-        return 'date'
-    elif 'number' in property_type:
-        return 'numeric'
-    elif 'integer' in property_type and 'string' in property_type:
-        return 'character varying'
-    elif 'boolean' in property_type:
-        return 'boolean'
-    elif 'integer' in property_type:
-        return 'bigint'
-    else:
-        return 'character varying'
+    types = schema_property['type']
+    if isinstance(types, (str, bytes)):
+        types = [types]
+    concrete_type = most_general_type(types)
+
+    if concrete_type == 'string':
+        # jsonschema doesn't have a type for dates, so we need to go by the format
+        if property_format == 'date-time':
+            return 'timestamp with time zone'
+        elif property_format == 'date':
+            return 'date'
+
+    if concrete_type not in JSONSCHEMA_TYPE_TO_POSTGRES_TYPE:
+        concrete_type = 'string'
+    return JSONSCHEMA_TYPE_TO_POSTGRES_TYPE[concrete_type]
 
 
 def inflect_name(name):

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -68,7 +68,8 @@ def most_general_type(types):
     converts between the types without error.
     """
     if not types:
-        raise ValueError('most_general_type: types requires at least 1 entry')
+        return 'string'
+
     types = get_usable_types(types)
 
     best_score, best_type = 0, None

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -46,6 +46,7 @@ _JSONSCHEMA_TYPE_CAN_CAST_TO = {
 def get_usable_types(types):
     # Null is not usable as a discrete type (all types are nullable)
     types = set(types) - {'null',}
+    # Return a new set that excludes any entry not in JSONSCHEMA_TYPES.
     return JSONSCHEMA_TYPES.intersection(types)
 
 

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -64,9 +64,8 @@ def most_general_type(types):
     Figures out the most general type in the list, which allows us to make a
     more intelligent choice about which postgres data type to use.
 
-    A type G is more general than a type T iff `cast(g AS t)` losslessly
-    converts g to t without error where `g` is of type `G` and `t` is of type
-    `T`.
+    A type G is more general than a type T iff `cast(t::T AS G)` losslessly
+    converts between the types without error.
     """
     if not types:
         raise ValueError('most_general_type: types requires at least 1 entry')

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -42,6 +42,11 @@ _JSONSCHEMA_TYPE_CAN_CAST_TO = {
     'null': ()
 }
 
+JSONSCHEMA_UNSUPPORTED_TYPES = {
+    # `null` is supported in postgres, but not as a type.
+    'null',
+}
+
 
 def get_castable_types(target_type):
     """
@@ -49,6 +54,7 @@ def get_castable_types(target_type):
     """
     accepts = set(_JSONSCHEMA_TYPE_CAN_CAST_TO.get(target_type, ()))
     accepts |= {target_type,}
+    accepts -= JSONSCHEMA_UNSUPPORTED_TYPES
     return accepts
 
 
@@ -63,7 +69,7 @@ def most_general_type(types):
     """
     if not types:
         raise ValueError('most_general_type: types requires at least 1 entry')
-    types = set(types)
+    types = set(types) - JSONSCHEMA_UNSUPPORTED_TYPES
 
     best_score, best_type = 0, None
 

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -64,8 +64,11 @@ def most_general_type(types):
     Figures out the most general type in the list, which allows us to make a
     more intelligent choice about which postgres data type to use.
 
-    A type G is more general than a type T iff `cast(t::T AS G)` losslessly
-    converts between the types without error.
+    A type G is generalizes to a type T iff `cast(t::T AS G)` losslessly
+    converts between the types without error. First we find the type that
+    generalizes to the most other types in `types`. If that type can generalize
+    to every type in types, we return it. If it can't, then we return 'string',
+    as it is the most general type.
     """
     if not types:
         return 'string'

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -271,8 +271,10 @@ def test_record_primary_key_string(record, key_props: list, expected: str, dbsyn
         (('array', 'null', 'boolean'), 'string'),
         # We don't know about these thypes, so again assume string is best
         (('fake type 1', 'fake type 2', 'fake type 3'), 'string'),
+
+        (('null', 'object'), 'object'),
     ],
-    ids=repr
+    ids=str
 )
 def test_most_general_type(types, expected):
     assert most_general_type(types) == expected

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -257,7 +257,7 @@ def test_record_primary_key_string(record, key_props: list, expected: str, dbsyn
     'types, expected',
     [
         # string always wins
-        (JSONSCHEMA_TYPES, 'string'),  
+        (sorted(tuple(JSONSCHEMA_TYPES)), 'string'),
         (('string', 'number'), 'string'),
 
         (('integer', 'number'), 'number'),
@@ -273,6 +273,7 @@ def test_record_primary_key_string(record, key_props: list, expected: str, dbsyn
         (('fake type 1', 'fake type 2', 'fake type 3'), 'string'),
 
         (('null', 'object'), 'object'),
+        (['number', None], 'number'),
     ],
     ids=str
 )

--- a/target_postgres/tests/tests.py
+++ b/target_postgres/tests/tests.py
@@ -1,6 +1,7 @@
+from collections import namedtuple
 import pytest
 from copy import deepcopy
-from target_postgres.db_sync import DbSync, column_type, flatten_record, flatten_schema
+from target_postgres.db_sync import DbSync, column_type, flatten_record, flatten_schema, most_general_type, JSONSCHEMA_TYPES
 
 BASE_SCHEMA = {
     'type': 'SCHEMA',
@@ -57,13 +58,18 @@ def dbsync_class():
         ({'type': ['array']}, 'jsonb'),
         ({'type': ['object', 'array'], 'format': 'date-time'}, 'jsonb'),
         ({'type': ['string'], 'format': 'date-time'}, 'timestamp with time zone'),
-        ({'type': ['boolean', 'integer', 'number'], 'format': 'date'}, 'date'),
+        ({'type': ['boolean', 'integer', 'number'], 'format': 'date'}, 'numeric'),
         ({'type': ['boolean', 'integer', 'number']}, 'numeric'),
         ({'type': ['integer', 'string']}, 'character varying'),
-        ({'type': ['boolean', 'integer']}, 'boolean'),
+        ({'type': ['boolean', 'integer']}, 'bigint'),
         ({'type': ['integer']}, 'bigint'),
         ({'type': ['string']}, 'character varying'),
-    ]
+        ({'type': ['null', 'array', 'string'], 'items': {'type': ['null', 'string']}}, 'character varying'),
+
+        # Ensure we don't get errors when we use an invalid type
+        ({'type': ['NOT A REAL TYPE!']}, 'character varying'),
+    ],
+    ids=repr
 )
 def test_column_type(prop: dict, expected: str):
     assert column_type(prop) == expected
@@ -245,3 +251,28 @@ def test_record_to_csv_row(record: dict, expected: list, dbsync_class: DbSync):
 def test_record_primary_key_string(record, key_props: list, expected: str, dbsync_class: DbSync):
     dbsync_class.stream_schema_message['key_properties'] = key_props
     assert dbsync_class.record_primary_key_string(record) == expected
+
+
+@pytest.mark.parametrize(
+    'types, expected',
+    [
+        # string always wins
+        (JSONSCHEMA_TYPES, 'string'),  
+        (('string', 'number'), 'string'),
+
+        (('integer', 'number'), 'number'),
+        (('boolean', 'integer', 'number'), 'number'),
+        (('boolean', 'integer'), 'integer'),
+
+        (('null', 'string'), 'string'),
+        (('array', 'object'), 'object'),
+
+        # None of these types generalize to each other, so we need to choose string as the general type
+        (('array', 'null', 'boolean'), 'string'),
+        # We don't know about these thypes, so again assume string is best
+        (('fake type 1', 'fake type 2', 'fake type 3'), 'string'),
+    ],
+    ids=repr
+)
+def test_most_general_type(types, expected):
+    assert most_general_type(types) == expected


### PR DESCRIPTION
JIRA ticket: https://pathlighthq.atlassian.net/browse/FUJ-3612

The following field was causing target postgres to choose "jsonb" as the type, when it should be "string":

```json
{
    ...
    "previous_value": {
        "type": [
            "null",
            "array",
            "string"
        ],
        ...
    },
    ...
}
```

This causes some string inputs to fail when we try to insert into that field, which breaks the tap (e.g. the value "1E263780" when interpreted as JSON is an absurdly large number that can't fit in whatever datatype postgres uses for JSON numbers). Instead, we need to choose "character varying" as the type, because we can cast to JSON if needed using custom_sql, but still avoid errors when running the tap.

JIRA ticket: https://pathlighthq.atlassian.net/browse/FUJ-3612

To make sure this change is valid, I went to a prod shell and downloaded all tap catalogs back to my local machine:

```python
[PROD]  In [1]: import json
           ...: with open('/remote/catalogs.json', 'w') as f:
           ...:     catalogs = []
           ...:     for tc in TapConfig.objects.all():
           ...:         catalogs.append(tc.catalog)
           ...:     json.dump(catalogs, f)
```

Back in this repo, I checked out master and ran a script that calls `column_type(property)` for all stream properties in all catalogs. I ran this script and saved the results in a file. Then I did the same thing on this PR branch and diffed the two output files to see what will change. I discovered that we will make 63 schema changes as a result of this PR. Here is a summary of those changes:

```
*** master.schema.out   2023-01-12 17:10:20.000000000 -0800
--- paul-target-postrgres-type-choosing.schema.out      2023-01-12 17:10:20.000000000 -0800

***************
*** 11 ****
! type=['null', 'object', 'string'], format=None, pg type=jsonb
--- 11 ----
! type=['null', 'object', 'string'], format=None, pg type=character varying

***************
*** 20 ****
! type=['null', 'array', 'string'], format=None, pg type=jsonb
--- 20 ----
! type=['null', 'array', 'string'], format=None, pg type=character varying

***************
*** 103 ****
! type=['null', 'boolean', 'integer'], format=None, pg type=boolean
--- 103 ----
! type=['null', 'boolean', 'integer'], format=None, pg type=bigint

***************
*** 353 ****
! type=['null', 'boolean', 'string'], format=None, pg type=boolean
--- 353 ----
! type=['null', 'boolean', 'string'], format=None, pg type=character varying
```

You can see here that in the case of booleans, objects and arrays we were using a more specific type than we should be (not all strings are valid jsonb, but all jsonb is a valid string, likewise with boolean). These changes should prevent errors when loading data into postgres.

The code I used to generate the output files is:

```python
import json

from target_postgres.db_sync import column_type

with open('catalogs.json') as f:
    catalogs = json.load(f)

seen = set()
for catalog_i, catalog in enumerate(catalogs):
    if 'streams' in catalog:
        for stream in catalog['streams']:
            schema = stream.get('schema', {})
            properties = schema.get('properties')
            for key, prop in sorted(properties.items(), key=lambda t: t[0]):
                prop_val = json.dumps(prop, sort_keys=True)
                if prop_val in seen:
                    continue
                seen.add(prop_val)
                try:
                    col_type = column_type(prop)
                except Exception as e:
                    col_type = e
                # print(catalog_i, stream.get('stream'), key, prop.get('type'), prop.get('format'), col_type)
                print(f'type={prop.get("type")},', f'format={prop.get("format")},', f'pg type={col_type}')
```