### PR TITLE
Use errors='surrogatepass' for the csv file

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -42,7 +42,12 @@ def emit_state(state):
 
 
 def new_csv_file_entry():
-    csv_f = io.TextIOWrapper(TemporaryFile(mode='w+b'), newline='\n', encoding='UTF-8')
+    csv_f = io.TextIOWrapper(
+        TemporaryFile(mode='w+b'),
+        newline='\n',
+        encoding='UTF-8',
+        errors='surrogatepass'
+    )
     writer = csv.writer(csv_f)
     return {'file': csv_f, 'writer': writer}
 


### PR DESCRIPTION
https://docs.python.org/3/library/codecs.html#error-handlers
```
In [24]:     csv_f = io.TextIOWrapper(
    ...:         TemporaryFile(mode='w+b'),
    ...:         newline='\n',
    ...:         encoding='UTF-8',
    ...:     )
    ...:     writer = csv.writer(csv_f)

In [25]: writer.writerow(['\ude0a'])
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-25-e0e2910df871> in <cell line: 1>()
----> 1 writer.writerow(['\ude0a'])

UnicodeEncodeError: 'utf-8' codec can't encode character '\ude0a' in position 0: surrogates not allowed

In [26]:     csv_f = io.TextIOWrapper(
    ...:         TemporaryFile(mode='w+b'),
    ...:         newline='\n',
    ...:         encoding='UTF-8',
    ...:         errors='surrogatepass'
    ...:     )
    ...:     writer = csv.writer(csv_f)

In [27]: writer.writerow(['\ude0a'])
Out[27]: 3
```